### PR TITLE
Rework plate naming priorities so that reader-supplied names can be used

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -420,14 +420,7 @@ public class ImportCandidates extends DirectoryWalker
                 ic.setDoThumbnails(config.doThumbnails.get());
                 ic.setNoStatsInfo(config.noStatsInfo.get());
                 String configImageName = config.userSpecifiedName.get();
-                if (configImageName == null)
-                {
-                    ic.setUserSpecifiedName(file.getName());
-                }
-                else
-                {
-                    ic.setUserSpecifiedName(configImageName);
-                }
+                ic.setUserSpecifiedName(configImageName);
                 ic.setUserSpecifiedDescription(config.userSpecifiedDescription.get());
                 ic.setCustomAnnotationList(config.annotations.get());
                 return ic;

--- a/components/blitz/src/ome/formats/importer/ImportFixture.java
+++ b/components/blitz/src/ome/formats/importer/ImportFixture.java
@@ -112,7 +112,6 @@ public class ImportFixture
         {
 		ic = new ImportContainer(file, fads.get(file),
 					null, null, null, null);
-		ic.setUserSpecifiedName(file.getAbsolutePath());
 		library.importImage(ic, 0, 0, 1);
         /*
 		library.importImage(file, 0, 0, 1, file.getAbsolutePath(),

--- a/components/blitz/src/ome/formats/model/PixelsProcessor.java
+++ b/components/blitz/src/ome/formats/model/PixelsProcessor.java
@@ -27,6 +27,7 @@ import static omero.rtypes.rstring;
 
 import static ome.formats.model.UnitsFactory.makeLength;
 
+import java.io.File;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -124,6 +125,8 @@ public class PixelsProcessor implements ModelProcessor {
       }
 
       // Ensure that the Image name is set
+
+      // name supplied by user
       String userSpecifiedName = store.getUserSpecifiedName();
       if (userSpecifiedName != null) {
         userSpecifiedName = userSpecifiedName.trim();
@@ -131,7 +134,9 @@ public class PixelsProcessor implements ModelProcessor {
           userSpecifiedName = null;
         }
       }
+      // name that will actually be set on the Image
       String saveName = "";
+      // name supplied by the reader
       String imageName;
       if (image.getName() != null && image.getName().getValue() != null) {
         imageName = image.getName().getValue().trim();
@@ -150,9 +155,17 @@ public class PixelsProcessor implements ModelProcessor {
           }
           saveName += " [" + imageName + "]";
         }
-      } else {
+      } else if (imageName != null) {
         saveName = imageName;
       }
+      else {
+        saveName = reader.getCurrentFile();
+        saveName = saveName.substring(saveName.lastIndexOf(File.separator) + 1);
+        if (reader.getSeriesCount() > 1) {
+          saveName += " [" + imageIndex + "]";
+        }
+      }
+      // TODO: remove this if/when name is switched to TEXT in the DB
       if (saveName != null && saveName.length() > 255) {
         saveName = '…' + saveName.substring(saveName.length() - 254);
       }

--- a/components/blitz/src/ome/formats/model/WellProcessor.java
+++ b/components/blitz/src/ome/formats/model/WellProcessor.java
@@ -26,6 +26,7 @@ package ome.formats.model;
 import static omero.rtypes.rint;
 import static omero.rtypes.rstring;
 
+import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -96,23 +97,14 @@ public class WellProcessor implements ModelProcessor {
     String userSpecifiedPlateName = store.getUserSpecifiedName();
     String userSpecifiedPlateDescription = store.getUserSpecifiedDescription();
 
-    // precedence order for plate naming:
-    //
-    // 1. user specified, if not default name of imported file
-    // 2. reader supplied, if not null
-    // 3. user specified (name of imported file)
-    // 4. "Plate"
     if (userSpecifiedPlateName != null) {
-      String currentFile = store.getReader().getCurrentFile();
-      if (!currentFile.endsWith(userSpecifiedPlateName) ||
-        plate.getName() == null)
-      {
-        plate.setName(rstring(userSpecifiedPlateName));
-      }
+      plate.setName(rstring(userSpecifiedPlateName));
     }
     if (plate.getName() == null) {
       log.warn("Missing plate name for: " + container.LSID);
-      plate.setName(rstring("Plate"));
+      String filename = store.getReader().getCurrentFile();
+      filename = filename.substring(filename.lastIndexOf(File.separator) + 1);
+      plate.setName(rstring(filename));
     }
 
     if (userSpecifiedPlateDescription != null) {

--- a/components/blitz/src/ome/formats/model/WellProcessor.java
+++ b/components/blitz/src/ome/formats/model/WellProcessor.java
@@ -95,15 +95,28 @@ public class WellProcessor implements ModelProcessor {
     Plate plate = (Plate) container.sourceObject;
     String userSpecifiedPlateName = store.getUserSpecifiedName();
     String userSpecifiedPlateDescription = store.getUserSpecifiedDescription();
+
+    // precedence order for plate naming:
+    //
+    // 1. user specified, if not default name of imported file
+    // 2. reader supplied, if not null
+    // 3. user specified (name of imported file)
+    // 4. "Plate"
     if (userSpecifiedPlateName != null) {
-      plate.setName(rstring(userSpecifiedPlateName));
-    }
-    if (userSpecifiedPlateDescription != null) {
-      plate.setDescription(rstring(userSpecifiedPlateDescription));
+      String currentFile = store.getReader().getCurrentFile();
+      if (!currentFile.endsWith(userSpecifiedPlateName) ||
+        plate.getName() == null)
+      {
+        plate.setName(rstring(userSpecifiedPlateName));
+      }
     }
     if (plate.getName() == null) {
       log.warn("Missing plate name for: " + container.LSID);
       plate.setName(rstring("Plate"));
+    }
+
+    if (userSpecifiedPlateDescription != null) {
+      plate.setDescription(rstring(userSpecifiedPlateDescription));
     }
     if (plate.getRows() == null) {
       plate.setRows(rint(1));


### PR DESCRIPTION
This is one attempt at resolving the long-standing issue of reader-supplied plate names being overwritten by the name of the imported file (which is set as the user specified name).  The default names appear to come from ome.formats.importer.ImportFixture, but changes were not made there so as to not affect non-SPW imports.

Changes here were written and tested in the context of Harmony work, but all plate imports will be impacted.  I would expect `bin/omero import -n TestPlateName Images/Index.idx.xml` to result in the same plate name (`TestPlateName`) with and without this change.  `bin/omero import Images/Index.idx.xml` results in a plate named `Index.idx.xml` without this, and should result in a plate named according to the `Name` tag under `Plate` in the `Index.idx.xml` file.
