### PR TITLE
OMERO.web: include plate acquisition start time in browsing tree

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -959,6 +959,9 @@ def _marshal_plate_acquisition(conn, row):
         start_time = datetime.utcfromtimestamp(unwrap(start_time) / 1000.0)
         end_time = datetime.utcfromtimestamp(unwrap(end_time) / 1000.0)
         plate_acquisition['name'] = '%s - %s' % (start_time, end_time)
+    elif start_time is not None:
+        start_time = datetime.utcfromtimestamp(unwrap(start_time) / 1000.0)
+        plate_acquisition['name'] = '%s' % start_time
     else:
         plate_acquisition['name'] = 'Run %d' % unwrap(pa_id)
 


### PR DESCRIPTION
This adds an extra case to the logic for setting the plate acquisition
name in the tree in the left-hand panel.  If a start time (but not an
end time) was set, then the name will be the start time instead of `Run $id`.

See https://github.com/glencoesoftware/openmicroscopy/issues/3

To test, import any one of the example Harmony plates.  Verify that the `starttime` on `plateacquisition` is set to a valid timestamp in the database.  Open the same plate in OMERO.web without this change, and verify that the corresponding plate acquisition is listed in the left-hand panel tree as `Run` followed by the ID number.  With this change, open the plate again (no need to reimport) and verify that the plate acquisition is now listed as a timestamp matching the value of `starttime`.
