### PR TITLE
Session timeouts and agents

### DIFF
--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -398,6 +398,8 @@
       <constructor-arg ref="currentDetails"/>
       <constructor-arg ref="sessionManager"/>
       <constructor-arg ref="securitySystem"/>
+      <constructor-arg value="${omero.sessions.max_user_time_to_live}"/>
+      <constructor-arg value="${omero.sessions.max_user_time_to_idle}"/>
      <property name="iceCommunicator" ref="Ice.Communicator"/>
   </bean>
 

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -260,6 +260,27 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <!--  SESSION PROPERTIES -->
+    <bean class="ome.system.Preference" id="omero.sessions.timeout">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.sessions.maximum">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.sessions.max_user_time_to_idle">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.sessions.max_user_time_to_live">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>

--- a/components/server/resources/ome/services/sec-primitives.xml
+++ b/components/server/resources/ome/services/sec-primitives.xml
@@ -153,6 +153,8 @@
     <property name="executor"        ref="executor"/>
     <property name="defaultTimeToIdle" value="${omero.sessions.timeout}"/>
     <property name="defaultTimeToLive" value="${omero.sessions.maximum}"/>
+    <property name="maxUserTimeToIdle" value="${omero.sessions.max_user_time_to_idle}"/>
+    <property name="maxUserTimeToLive" value="${omero.sessions.max_user_time_to_live}"/>
     <property name="counterFactory"  ref="sessionCounterFactory"/>
     <property name="readOnly"        ref="readOnlyStatus"/>
     <property name="sessionProvider" ref="sessionProvider"/>

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -166,17 +166,18 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
 
     public void setDefaultTimeToIdle(long defaultTimeToIdle) {
         this.defaultTimeToIdle = defaultTimeToIdle;
-        this.maxUserTimeToIdle = Math.min(Long.MAX_VALUE / 10,
-                defaultTimeToIdle);
-        this.maxUserTimeToIdle *= 10;
+    }
+
+    public void setMaxUserTimeToIdle(long maxUserTimeToIdle) {
+        this.maxUserTimeToIdle = maxUserTimeToIdle;
     }
 
     public void setDefaultTimeToLive(long defaultTimeToLive) {
         this.defaultTimeToLive = defaultTimeToLive;
-        this.maxUserTimeToLive = Math.min(Long.MAX_VALUE / 10,
-                defaultTimeToLive);
-        this.maxUserTimeToLive *= 10;
+    }
 
+    public void setMaxUserTimeToLive(long maxUserTimeToLive) {
+        this.maxUserTimeToLive = maxUserTimeToLive ;
     }
 
     public void setPrincipalHolder(PrincipalHolder principal) {

--- a/components/tools/OmeroJava/test/integration/AgentTest.java
+++ b/components/tools/OmeroJava/test/integration/AgentTest.java
@@ -1,0 +1,142 @@
+/*
+ *   Copyright 2019 Glencoe Software, Inc. All rights reserved.
+ *   Use is subject to license terms supplied in LICENSE.txt
+ */
+package integration;
+
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.testng.annotations.BeforeClass;
+
+import omero.cmd.UpdateSessionTimeoutRequest;
+import omero.cmd.Response;
+import omero.model.Session;
+import omero.sys.EventContext;
+import omero.sys.Principal;
+import omero.api.IConfigPrx;
+import omero.api.ISessionPrx;
+import omero.cmd.OK;
+
+import static omero.rtypes.rlong;
+
+/**
+ * Tests for changing the UserAgent when creating sessions
+ *
+ */
+public class AgentTest extends AbstractServerTest {
+
+    protected static final String TEST_AGENT = "sessionTestAgent";
+
+    protected static final Map<String, String> TEST_AGENT_CONTEXT =
+            ImmutableMap.of(omero.constants.AGENT.value, TEST_AGENT);
+
+    /** Helper reference to the <code>IConfig</code> service. */
+    protected IConfigPrx iConfig;
+
+    /** Helper reference to the <code>ISession</code> service. */
+    protected ISessionPrx iSession;
+
+    /** Helper reference to <code>EventContext</code> of the active user. */
+    protected EventContext ctx;
+
+    /** Server default session time to live. */
+    protected long timeToLive;
+
+    /** Server default session time to idle. */
+    protected long timeToIdle;
+
+    /** Server default user maximum time to live. */
+    protected long maxUserTimeToLive;
+
+    /** Server default user maximum time to live. */
+    protected long maxUserTimeToIdle;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        ctx = newUserAndGroup("rw----");
+        iConfig = factory.getConfigService();
+        iSession = factory.getSessionService();
+        timeToLive = Long.parseLong(iConfig.getConfigValue(
+                "omero.sessions.maximum"));
+        timeToIdle = Long.parseLong(iConfig.getConfigValue(
+                "omero.sessions.timeout"));
+        maxUserTimeToLive = Long.parseLong(iConfig.getConfigValue(
+                "omero.sessions.max_user_time_to_live"));
+        maxUserTimeToIdle = Long.parseLong(iConfig.getConfigValue(
+                "omero.sessions.max_user_time_to_idle"));
+    }
+
+    @Test
+    public void testSetAgent() throws Exception {
+        Session session = iSession.createUserSession(
+                0, 2000, ctx.groupName, TEST_AGENT_CONTEXT);
+        Assert.assertEquals(TEST_AGENT, session.getUserAgent().getValue());
+    }
+
+    @Test
+    public void testSetAgentCreateSessionWithTimeout() throws Exception {
+        Principal principal = new Principal(
+                ctx.userName, ctx.groupName, "Test", ctx.groupPermissions);
+        ISessionPrx iSession = root.getSession().getSessionService();
+        Session session = iSession.createSessionWithTimeout(
+                principal, 1000, TEST_AGENT_CONTEXT);
+        Assert.assertEquals(TEST_AGENT, session.getUserAgent().getValue());
+    }
+
+    @Test
+    public void testSetAgentCreateSessionWithTimeouts() throws Exception {
+        Principal principal = new Principal(
+                ctx.userName, ctx.groupName, "Test", ctx.groupPermissions);
+        ISessionPrx iSession = root.getSession().getSessionService();
+        Session session = iSession.createSessionWithTimeouts(
+                principal, 1000, 2000, TEST_AGENT_CONTEXT);
+        Assert.assertEquals(TEST_AGENT, session.getUserAgent().getValue());
+    }
+
+    @Test
+    public void testUpdateSessionTimeToIdleAndTimeToLive() throws Exception {
+        Session session = iSession.createUserSession(
+                timeToLive, timeToIdle, ctx.groupName);
+        System.err.println(session.getUuid().getValue());
+        UpdateSessionTimeoutRequest change = new UpdateSessionTimeoutRequest(
+                session.getUuid().getValue(), rlong(timeToIdle + 1),
+                rlong(timeToIdle + 2));
+        Response response = doChange(change);
+        Assert.assertTrue(response instanceof OK);
+        session = iSession.getSession(session.getUuid().getValue());
+        Assert.assertEquals(session.getTimeToLive().getValue(), timeToIdle + 1);
+        Assert.assertEquals(session.getTimeToIdle().getValue(), timeToIdle + 2);
+    }
+
+    @Test
+    public void testUpdateSessionTimeToIdleBeyondMaximum() throws Exception {
+        Session session = iSession.createUserSession(
+                timeToLive, timeToIdle, ctx.groupName);
+        UpdateSessionTimeoutRequest change = new UpdateSessionTimeoutRequest(
+                session.getUuid().getValue(), rlong(timeToLive),
+                rlong(maxUserTimeToIdle + 1));
+        Response response = doChange(change);
+        Assert.assertTrue(response instanceof OK);
+        session = iSession.getSession(session.getUuid().getValue());
+        Assert.assertEquals(session.getTimeToLive().getValue(), timeToLive);
+        Assert.assertEquals(session.getTimeToIdle().getValue(),
+                maxUserTimeToIdle);
+    }
+
+    @Test(expectedExceptions=AssertionError.class)
+    public void testNonAdminDisabling() throws Exception {
+        Session session = iSession.createUserSession(
+                timeToLive, timeToIdle, ctx.groupName);
+        long timeToLive = Long.parseLong(iConfig.getConfigValue(
+                "omero.sessions.timeout"));
+        UpdateSessionTimeoutRequest change = new UpdateSessionTimeoutRequest(
+                session.getUuid().getValue(), rlong(timeToLive), rlong(0));
+        doChange(change);
+    }
+
+}

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -224,8 +224,12 @@ class SessionsControl(UserGroupControl):
             "--no-purge", dest="purge", action="store_false",
             help="Do not remove inactive sessions")
 
-        parser.add(sub, self.who, (
+        who = parser.add(sub, self.who, (
             "List all active server sessions\n\n" + WHOHELP))
+        who.add_argument(
+            "--show-uuid", help="Show uuids for sessions",
+            action="store_true")
+
 
         keepalive = parser.add(
             sub, self.keepalive, "Keeps the current session alive")
@@ -774,6 +778,7 @@ class SessionsControl(UserGroupControl):
         self.ctx.out(str(Table(*columns)))
 
     def who(self, args):
+        show_uuid = args.show_uuid
         client = self.ctx.conn(args)
         uuid = self.ctx.get_event_context().sessionUuid
         req = omero.cmd.CurrentSessionsRequest()
@@ -788,12 +793,14 @@ class SessionsControl(UserGroupControl):
             extra = set()
             results = {"name": [], "group": [],
                        "logged in": [], "agent": [],
-                       "timeout": []}
+                       "timeout": [], "uuid": []}
 
             # Preparse data to find extra columns
             for idx, s in enumerate(rsp.sessions):
                 for k in rsp.data[idx].keys():
                     extra.add(k)
+            if show_uuid:
+                headers.append("uuid")
             for add in sorted(extra):
                 headers.append(add)
                 results[add] = []
@@ -826,6 +833,7 @@ class SessionsControl(UserGroupControl):
                     results["agent"].append(unwrap(s.userAgent))
                     results["timeout"].append(
                         self._parse_timeout(s.timeToIdle))
+                    results["uuid"].append(ec.sessionUuid)
                 else:
                     # Insufficient privileges. The EventContext
                     # will be missing fields as well.
@@ -833,6 +841,7 @@ class SessionsControl(UserGroupControl):
                     results["logged in"].append(msg)
                     results["agent"].append(msg)
                     results["timeout"].append(msg)
+                    results["uuid"].append(msg)
 
             from omero.util.text import Table, Column
             columns = tuple([Column(x, results[x]) for x in headers])

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -642,12 +642,20 @@ omero.checksum.supported=SHA1-160, MD5-128, Murmur3-128, Murmur3-32, CRC-32, Adl
 ## straightforward
 #############################################
 
-# Sets the duration of inactivity in milliseconds after which
-# a login is required.
+# Sets the default duration of inactivity in milliseconds after
+# which a login is required.
 omero.sessions.timeout=600000
+# Sets the default duration before a login is required; 0
+# signifies never.
 omero.sessions.maximum=0
 omero.sessions.sync_interval=120000
 omero.sessions.sync_force=1800000
+# Sets the maximum duration a user can request before a login
+# is required due to inactivity.
+omero.sessions.max_user_time_to_idle=6000000
+# Sets the maximum duration a user can request before a login
+# is required (0 signifies never).
+omero.sessions.max_user_time_to_live=0
 
 #############################################
 ## threading configuring


### PR DESCRIPTION
# What this PR does

A system wide, configurable maximum time to idle and time to live is now in place.  Regular users are allowed to create new sessions with timeouts up to these limits.  The previous limits were 10x the default time to idle and time to live.  These new properties are:

* `omero.sessions.max_user_time_to_idle`
* `omero.sessions.max_user_time_to_live`

Defaults are set to 6000000 (100 minutes) and 0 (never) respectively which reflect the existing defaults. The values of these properties, as well as the existing default session timeout and time to live properties (`omero.sessions.timeout` and `omero.sessions.maximum`), are now available to clients via the config service and can be set globally via `omero config set`. Users may now make predictable and informed timeout choices during session creation.

Updating session timeouts via `omero sessions timeout` is now possible and conforms to the aforementioned default maxima.

`omero sessions who` has also been updated to optionally allow display of session UUIDs for those who have permissions to see them.

Furthermore, it is now possible to pass an "omero.agent" as part of call context to set the user agent on sessions created using the session service.  For example:

    createUserSession(0, 600000, 'test', {'omero.agent': 'my agent'})

This was previously only respected after calling `setAgent()` when calling `createSession()` on an OMERO client object.

# Testing this PR

1. Integration tests for session agent manipulation are provided

2. Utilize `omero sessions timeout`, `omero sessions who` and the manipulation of the user max time to idle and max time to live with a variety of settings.